### PR TITLE
Overflow scrolling for vertical tool-bars

### DIFF
--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -9,7 +9,6 @@
   border: 1px solid @base-border-color;
   color: @text-color;
   display: flex;
-  flex-wrap: wrap;
   justify-content: flex-start;
 
   button.tool-bar-btn {
@@ -17,7 +16,7 @@
     background-image: inherit;
     border-color: @base-background-color;
     cursor: pointer;
-    float: left;
+    flex: 0 0 auto;
     margin: @button-margin-size;
     padding: 0;
 
@@ -42,16 +41,12 @@
     border: 0 none;
     border-left: @button-border-size solid @button-background-color;
     border-right: @button-border-size solid @button-border-color;
-    display: block;
-    float: left;
     margin: @button-margin-size + 3 0;
   }
   &.tool-bar-vertical .tool-bar-spacer {
     border: 0 none;
     border-bottom: @button-border-size solid @button-background-color;
     border-top: @button-border-size solid @button-border-color;
-    display: block;
-    float: left;
     margin: 0 @button-margin-size + 3;
   }
 
@@ -71,10 +66,15 @@
     &.tool-bar-horizontal {
       flex-direction: row;
       width: 100%;
+      flex-wrap: wrap;
     }
     &.tool-bar-vertical {
       flex-direction: column;
       height: 100%;
+      overflow-x: auto;
+      &::-webkit-scrollbar {
+        display: none;
+      }
     }
 
     .tool-bar-btn {


### PR DESCRIPTION
This PR is on top of @jerone's [multi-row-tool-bar](https://github.com/jerone/tool-bar/tree/issues/multi-row-tool-bar) branch. It adds overflow scrolling, but only to `left/right` positions. For `top/bottom` position, it still wraps.